### PR TITLE
fix(block-oracle): allow yarn lockfile updates during Docker build

### DIFF
--- a/block-oracle/Dockerfile
+++ b/block-oracle/Dockerfile
@@ -46,7 +46,7 @@ RUN cd block-oracle \
   && rm -rf target
 
 # Pre-install dependencies
-RUN cd block-oracle/packages/subgraph && yarn install --frozen-lockfile
+RUN cd block-oracle/packages/subgraph && yarn
 RUN cd contracts/packages/data-edge && pnpm install --no-frozen-lockfile
 
 # Copy and setup run script


### PR DESCRIPTION
  Removes --frozen-lockfile flag that was causing build failures due to
  outdated yarn.lock in upstream repository.